### PR TITLE
Fix invalid local files path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,15 @@ INSTALL_STACK
 COPY --exclude=Makefile . /build
 WORKDIR /build
 ARG INSTALL_NEW_GHC
+ARG ROOT
 RUN <<INSTALL_PACKAGE
+printf "\nconfigure-options:\n  \$everything:\n  - --datadir=%s" "${ROOT}/share">> stack.yaml
 stack build --dry-run
 ( test -z ${INSTALL_NEW_GHC+x}\
   || rm -rf /home/stackage/.stack/programs/x86_64-linux/ghc-* )
 make -f Makefile.build -e build
 INSTALL_PACKAGE
 ARG PKG_DB
-ARG ROOT
 COPY Makefile /build
 RUN <<MOVE_PKG_DB
 make -e install


### PR DESCRIPTION
The package DB files contain paths for static files like fonts, etc. that only exist inside the docker container (at `home/root/.stack/..`). This causes "file not found" exceptions when running the interpreter, e.g. with SVGImage. 

The only consistent way to sidestep this is setting the `datadir` path explicitly via stack.yaml options. It is not possible to set this directly by calling stack. Additionally, even though this option is for cabal it can not be set in cabal itself. The behaviour when setting the path in cabal is actually different than when setting it in stack (none of the files are written to the specified path). This is supposedly a bug, but works in our favour.

So I'm appending the option to the end of the stack.yaml file. The finished database then contains all of the additional files in the share folder.   