### PR TITLE
Rewrite binary paths after creating the database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIB_ROOT:=$(ROOT)/lib
 DOC_ROOT:=$(ROOT)/doc
 DATA_ROOT:=$(ROOT)/share
 # CONFIGURABLE RELOCATE_BINARY_PATHS
-RELOCATE_BINARY_PATHS:=/build/relocate-binary-data-paths.sh
+RELOCATE_BINARY_PATHS?=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))relocate-binary-data-paths.sh
 # CONFIGURABLE PKG_DB
 PKG_DB:=$(ROOT)/pkgdb
 STACK_CALL:=STACK_ROOT=$(STACK_ROOT) $(STACK)
@@ -146,7 +146,7 @@ relocate-binary-data-paths: $(TARGET_LIB_DIRS) $(TARGET_DATA_DIRS)
 	  test -n "$$old" || continue; \
 	  printf '%s\t%s\n' "$$old" "$(DATA_ROOT)/$$(basename "$$old")" >> "$$tmp"; \
 	done; \
-	$(RELOCATE_BINARY_PATHS) "$$tmp" "$(LIB_ROOT)"
+	$(SHELL) "$(RELOCATE_BINARY_PATHS)" "$$tmp" "$(LIB_ROOT)"
 
 $(PKG_DB)/package.cache: $(STACK_LOCK) $(TARGET_DIRS) $(PKG_DB_FILES)
 	$(GHC_PKG) recache --package-db=$(PKG_DB)

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ ROOT:=/tmp/foo
 LIB_ROOT:=$(ROOT)/lib
 DOC_ROOT:=$(ROOT)/doc
 DATA_ROOT:=$(ROOT)/share
+# CONFIGURABLE RELOCATE_BINARY_PATHS
+RELOCATE_BINARY_PATHS:=/build/relocate-binary-data-paths.sh
 # CONFIGURABLE PKG_DB
 PKG_DB:=$(ROOT)/pkgdb
 STACK_CALL:=STACK_ROOT=$(STACK_ROOT) $(STACK)
@@ -134,7 +136,17 @@ $(PKG_DB)/%: $(SNAPSHOT_PKG_DB)/% $(STACK_LOCK)
 	sed '$($@_import)$($@_data)$($@_html)' $< > $@
 endif
 
-install: build | $(PKG_DB) $(DATA_ROOT) $(LIB_ROOT) $(DOC_ROOT) $(PKG_DB)/package.cache
+install: build | $(PKG_DB) $(DATA_ROOT) $(LIB_ROOT) $(DOC_ROOT) $(PKG_DB)/package.cache relocate-binary-data-paths
+
+.PHONY: relocate-binary-data-paths
+relocate-binary-data-paths: $(TARGET_LIB_DIRS) $(TARGET_DATA_DIRS)
+	@tmp="$$(mktemp)"; \
+	trap 'rm -f "$$tmp"' EXIT; \
+	for old in $(DATA_DIRS); do \
+	  test -n "$$old" || continue; \
+	  printf '%s\t%s\n' "$$old" "$(DATA_ROOT)/$$(basename "$$old")" >> "$$tmp"; \
+	done; \
+	$(RELOCATE_BINARY_PATHS) "$$tmp" "$(LIB_ROOT)"
 
 $(PKG_DB)/package.cache: $(STACK_LOCK) $(TARGET_DIRS) $(PKG_DB_FILES)
 	$(GHC_PKG) recache --package-db=$(PKG_DB)

--- a/relocate-binary-data-paths.sh
+++ b/relocate-binary-data-paths.sh
@@ -12,9 +12,7 @@ set -eu
 #
 # REWRITE_MAP is tab-separated: OLD_PATH<TAB>NEW_PATH, one rewrite per line.
 # Replacement strings are kept exactly the same byte length. When NEW_PATH is
-# shorter, it is padded with harmless directory components such as /, /., /./.
-# This avoids changing binary file sizes and avoids NUL padding, which is safer
-# for both C strings and length-prefixed literals.
+# shorter, it is padded to preserve the length.
 
 export LC_ALL=C
 
@@ -41,7 +39,7 @@ pad_to_old_length() {
 new path is longer than old path; cannot patch safely:
   old ($old_len): $old
   new ($new_len): $new
-Use a shorter ROOT/PKG_DB export path or rebuild the package with a relocatable prefix.
+Use a shorter ROOT/PKG_DB export path.
 ERR
     exit 1
   fi

--- a/relocate-binary-data-paths.sh
+++ b/relocate-binary-data-paths.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env sh
+set -eu
+
+# Rewrite baked-in Cabal data-dir paths in copied Haskell libraries.
+#
+# Cabal's generated Paths_* modules may compile an absolute data-dir such as
+# /root/.stack/snapshots/.../share/... into .a/.so/.hi files. The package
+# registration files can be sed-rewritten, but compiled literals need a
+# binary-safe in-place rewrite as well.
+#
+# Usage: relocate-binary-data-paths.sh REWRITE_MAP LIB_ROOT
+#
+# REWRITE_MAP is tab-separated: OLD_PATH<TAB>NEW_PATH, one rewrite per line.
+# Replacement strings are kept exactly the same byte length. When NEW_PATH is
+# shorter, it is padded with harmless directory components such as /, /., /./.
+# This avoids changing binary file sizes and avoids NUL padding, which is safer
+# for both C strings and length-prefixed literals.
+
+export LC_ALL=C
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 REWRITE_MAP LIB_ROOT" >&2
+  exit 2
+fi
+
+map_file=$1
+lib_root=$2
+
+if [ ! -s "$map_file" ] || [ ! -d "$lib_root" ]; then
+  exit 0
+fi
+
+pad_to_old_length() {
+  old=$1
+  new=$2
+  old_len=${#old}
+  new_len=${#new}
+
+  if [ "$new_len" -gt "$old_len" ]; then
+    cat >&2 <<ERR
+new path is longer than old path; cannot patch safely:
+  old ($old_len): $old
+  new ($new_len): $new
+Use a shorter ROOT/PKG_DB export path or rebuild the package with a relocatable prefix.
+ERR
+    exit 1
+  fi
+
+  diff=$((old_len - new_len))
+  suffix=
+  while [ "$diff" -ge 2 ]; do
+    suffix=${suffix}/.
+    diff=$((diff - 2))
+  done
+  if [ "$diff" -eq 1 ]; then
+    suffix=${suffix}/
+  fi
+
+  printf '%s' "${new}${suffix}"
+}
+
+tab=$(printf '\t')
+rewrites_file=$(mktemp)
+hits_file=$(mktemp)
+log_file=$(mktemp)
+trap 'rm -f "$rewrites_file" "$hits_file" "$log_file"' HUP INT TERM EXIT
+
+# Precompute padded replacements. This fails before touching binaries if any
+# replacement would be too long.
+while IFS= read -r line || [ -n "${line:-}" ]; do
+  [ -n "${line:-}" ] || continue
+  case $line in
+    *"$tab"*) ;;
+    *) echo "bad rewrite-map line, expected OLD<TAB>NEW: $line" >&2; exit 2 ;;
+  esac
+  old=${line%%$tab*}
+  new=${line#*$tab}
+  padded=$(pad_to_old_length "$old" "$new")
+  if [ "$old" != "$padded" ]; then
+    printf '%s\t%s\n' "$old" "$padded" >> "$rewrites_file"
+  fi
+done < "$map_file"
+
+if [ ! -s "$rewrites_file" ]; then
+  exit 0
+fi
+
+# Deliberately avoid following symlinks so this cannot patch outside LIB_ROOT.
+find "$lib_root" -type f -print | while IFS= read -r file; do
+  file_hits=0
+
+  while IFS= read -r line || [ -n "${line:-}" ]; do
+    old=${line%%$tab*}
+    padded=${line#*$tab}
+
+    : > "$hits_file"
+    if grep -aobF -- "$old" "$file" > "$hits_file"; then
+      while IFS=: read -r offset _; do
+        [ -n "$offset" ] || continue
+        printf '%s' "$padded" | dd of="$file" bs=1 seek="$offset" conv=notrunc status=none
+        file_hits=$((file_hits + 1))
+      done < "$hits_file"
+    fi
+  done < "$rewrites_file"
+
+  if [ "$file_hits" -gt 0 ]; then
+    printf '%s\t%s\n' "$file_hits" "$file" >> "$log_file"
+  fi
+done
+
+if [ -s "$log_file" ]; then
+  patched_files=$(wc -l < "$log_file" | awk '{print $1}')
+  patched_occurrences=$(awk '{sum += $1} END {print sum + 0}' "$log_file")
+  echo "relocated ${patched_occurrences} baked-in data-dir path(s) in ${patched_files} file(s) under ${lib_root}"
+fi
+
+rm -f "$rewrites_file" "$hits_file" "$log_file"
+trap - HUP INT TERM EXIT


### PR DESCRIPTION
closes #5 

A bit iffy as this will fail if the old path is longer than what was previously in the binary file. This should always work for us in practise though: The standard `.stack/...` path that is in the files by default follows a bunch of folders and is quite long.

There probably is some way to directly make sure the correct files are written to file when the database is first created, but that would require a pretty deep rewrite of the main script here. I'll open a new issue on that; maybe something to do in the long run to clean this up.